### PR TITLE
feat(frontend): base de UI + template de búsqueda y ruta

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,22 @@
+
+from flask import Flask, render_template, redirect, url_for
+import os
+
+app = Flask(__name__, static_folder="static", template_folder="templates")
+
+BACKEND_URL = os.environ.get("BACKEND_URL", "http://127.0.0.1:5001")
+
+@app.route("/")
+def home():
+    return redirect(url_for("buscar"))
+
+@app.route("/buscar")
+def buscar():
+
+    materias = []  # sin datos hardcodeados
+    return render_template("busqueda.html",
+                           materias=materias,
+                           backend_url=BACKEND_URL)
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)

--- a/static/css/skillmatch_v2.css
+++ b/static/css/skillmatch_v2.css
@@ -1,0 +1,186 @@
+:root{
+  /* Paleta vibrante (azules/violáceos) */
+  --ink: #0b1424;
+  --muted: #7e8aa8;
+
+  --primary: #3b82f6;   /* azul vivo */
+  --primary-2: #7aa8ff; /* brillo */
+  --accent: #9c6bff;    /* violeta neón */
+
+  --glass: rgba(255,255,255,.08);
+  --line: rgba(255,255,255,.12);
+  --card: rgba(15, 23, 42, .55);
+  --chip: rgba(255,255,255,.10);
+
+  --shadow: 0 20px 60px rgba(0,0,0,.35);
+}
+
+/* ===== Fondo futurista (neón + blur) ===== */
+html,body{height:100%}
+body{
+  margin:0; font-family:Inter, system-ui, Segoe UI, Roboto, Ubuntu, Cantarell, Arial;
+  color:#eaf1ff;
+  background:
+    radial-gradient(900px 600px at 10% -10%, rgba(60,110,255,.35), transparent 60%),
+    radial-gradient(900px 600px at 100% 0%, rgba(156,107,255,.28), transparent 60%),
+    linear-gradient(180deg, #0a1224 0%, #0b1020 100%);
+  background-attachment: fixed;
+  position: relative; overflow-x:hidden;
+}
+body::before, body::after{
+  content:""; position:fixed; inset:-20%;
+  background:
+    radial-gradient(40% 30% at 30% 15%, rgba(60,110,255,.23), transparent 60%),
+    radial-gradient(30% 25% at 70% 25%, rgba(156,107,255,.20), transparent 60%),
+    radial-gradient(35% 28% at 50% 80%, rgba(90,200,255,.18), transparent 60%);
+  filter: blur(50px) saturate(1.1);
+  animation: drift 18s ease-in-out infinite alternate;
+  pointer-events:none; z-index:-1;
+}
+body::after{ animation-duration: 26s; animation-direction: alternate-reverse; opacity:.7 }
+@keyframes drift{
+  0%{ transform: translate3d(-1%, -2%, 0) scale(1.01) }
+  100%{ transform: translate3d(2%, 1%, 0) scale(1.03) }
+}
+
+/* ===== Util ===== */
+*{box-sizing:border-box}
+.container{max-width:1200px; margin:0 auto; padding:0 1rem}
+
+/* ===== Header ===== */
+.site-header{
+  position:sticky; top:0; z-index:20;
+  background:rgba(8,12,24,.65); backdrop-filter: blur(10px) saturate(1.2);
+  border-bottom:1px solid var(--line);
+}
+.header-inner{display:flex; align-items:center; justify-content:space-between; padding:.8rem 0}
+.brand{text-decoration:none; color:#eef4ff; font-weight:800; letter-spacing:.3px}
+.brand span{background:linear-gradient(90deg, var(--primary), var(--accent)); -webkit-background-clip:text; background-clip:text; color:transparent}
+.nav a{color:#cfd9ff; text-decoration:none; margin-left:1rem; opacity:.85}
+.nav a:hover{opacity:1}
+
+/* ===== Hero ===== */
+.hero{padding:2.4rem 0 1.2rem}
+.hero h1{margin:.2rem 0 .35rem; font-size:46px; letter-spacing:.6px}
+.hero .mark{
+  background-image: linear-gradient(90deg, var(--primary), var(--accent));
+  -webkit-background-clip:text; background-clip:text;
+  -webkit-text-fill-color: transparent; color: transparent; display:inline-block;
+}
+.lead{color:#aab7dc; margin:0 0 1.1rem}
+
+.searchbar{display:flex; gap:.7rem; align-items:center; flex-wrap:wrap}
+.input-wrap{position:relative; flex:1}
+.searchbar input{
+  width:100%; background:var(--glass); border:1px solid var(--line); border-radius:14px;
+  padding:1rem 3.2rem 1rem 1rem; color:#e9f1ff; outline:none; box-shadow: var(--shadow);
+}
+.searchbar input::placeholder{color:#9fb2e6}
+.hint{position:absolute; right:.6rem; top:50%; transform:translateY(-50%); color:#aab7dc; font-size:.85rem}
+.hint span{border:1px solid var(--line); padding:.05rem .35rem; border-radius:6px; background:var(--chip)}
+
+.btn{padding:.8rem 1.05rem; border-radius:12px; border:1px solid transparent; font-weight:700; cursor:pointer}
+.btn-primary{background:linear-gradient(90deg, var(--primary), var(--accent)); color:#0a1020; box-shadow: var(--shadow)}
+.btn-primary:hover{filter:brightness(1.05)}
+.btn-ghost{background:transparent; border:1px solid var(--line); color:#eaf1ff}
+.btn-ghost:hover{background:rgba(255,255,255,.06)}
+
+/* ===== Layout principal ===== */
+.layout{display:grid; grid-template-columns:340px 1fr; gap:1.6rem; margin-top:1rem}
+@media (max-width:1000px){ .layout{grid-template-columns:1fr} }
+
+/* ===== Filtros (glassmorphism) ===== */
+.filters{
+  align-self:start; position:sticky; top:92px; background:var(--card);
+  border:1px solid var(--line); border-radius:18px; padding:1rem; box-shadow: var(--shadow)
+}
+fieldset{border:0; margin:0 0 1rem}
+legend{font-weight:800; margin-bottom:.5rem}
+.muted{color:#aab7dc}
+.input-with-icon{position:relative}
+.input-with-icon input{
+  width:100%; padding:.7rem .9rem .7rem 2.2rem; border:1px solid var(--line); border-radius:12px;
+  background:var(--glass); color:#eaf1ff; outline:none;
+}
+.input-with-icon .icon{position:absolute; left:.65rem; top:.45rem; opacity:.8}
+.checklist{
+  max-height:260px; overflow:auto; border:1px solid var(--line); border-radius:12px;
+  padding:.4rem; background:rgba(255,255,255,.03)
+}
+.checklist.tiny{max-height:unset}
+.checklist label{
+  display:flex; align-items:center; gap:.6rem; padding:.5rem .4rem; border-radius:10px; cursor:pointer;
+}
+.checklist label:hover{background:rgba(255,255,255,.05)}
+
+/* Checkbox custom accesible */
+.ck{appearance:none; position:absolute; opacity:0; pointer-events:none}
+.ckbox{
+  width:20px; height:20px; border-radius:7px; border:2px solid var(--primary-2); background:transparent;
+  display:inline-grid; place-items:center; transition:.15s, box-shadow .2s;
+  box-shadow: 0 0 0px rgba(123,167,255,.0);
+}
+.ck:checked + .ckbox{background:linear-gradient(90deg, var(--primary), var(--accent)); border-color:transparent; box-shadow:0 0 12px rgba(105,160,255,.45)}
+.ck:checked + .ckbox::after{content:""; width:10px; height:10px; border-radius:3px; background:#0b1120}
+.cklabel{user-select:none}
+
+/* ===== Results ===== */
+.results .results-bar{display:flex; justify-content:space-between; align-items:center; gap:.8rem; margin-bottom:.9rem; flex-wrap:wrap}
+.select{display:flex; align-items:center; gap:.5rem}
+select{
+  background:var(--glass); color:#eaf1ff; border:1px solid var(--line);
+  border-radius:10px; padding:.55rem .7rem
+}
+.chips{display:flex; gap:.45rem; flex-wrap:wrap; margin:.7rem 0 1rem}
+.chip{background:var(--chip); border:1px solid var(--line); border-radius:999px; padding:.28rem .65rem; font-size:.9rem}
+.chip button{margin-left:.35rem; border:none; background:transparent; color:#cfe2ff; cursor:pointer}
+
+/* Cards y grilla */
+.cards{list-style:none; padding:0; margin:0; display:grid; gap:1rem; grid-template-columns:repeat(2, minmax(0,1fr))}
+@media (max-width:860px){ .cards{grid-template-columns:1fr} }
+.card{
+  background:var(--card); border:1px solid var(--line); border-radius:18px; padding:1rem; box-shadow: var(--shadow);
+  transition: transform .1s ease, border-color .2s ease;
+}
+.card:hover{transform: translateY(-2px); border-color:rgba(130,170,255,.35)}
+.card h3{margin:.15rem 0 .45rem}
+.meta{color:#b9c6ea; font-size:.92rem; display:flex; gap:.6rem; flex-wrap:wrap}
+.badge{display:inline-block; border:1px solid var(--line); background:rgba(255,255,255,.06); border-radius:999px; padding:.12rem .55rem; font-size:.78rem}
+.tags{display:flex; gap:.4rem; flex-wrap:wrap; margin:.45rem 0}
+.desc{color:#d6e3ff}
+.actions{display:flex; gap:.6rem; margin-top:.75rem}
+
+/* Empty state (sin datos) */
+.empty-state{
+  border:1px dashed var(--line); border-radius:18px; padding:2rem; text-align:center;
+  background:rgba(255,255,255,.03)
+}
+.empty-state .holo{display:flex; justify-content:center; gap:.5rem; margin-bottom:.6rem}
+.empty-state .dot{width:10px; height:10px; border-radius:50%;
+  background: radial-gradient(circle at 30% 30%, #fff, rgba(255,255,255,.1) 60%);
+  box-shadow: 0 0 18px rgba(150,190,255,.45);
+  animation: pulse 1.6s ease-in-out infinite;
+}
+.empty-state .dot:nth-child(2){animation-delay:.15s}
+.empty-state .dot:nth-child(3){animation-delay:.3s}
+@keyframes pulse{50%{ transform:scale(1.25) }}
+
+/* Paginación */
+.pagination{display:flex; gap:.6rem; justify-content:center; margin:1.1rem 0}
+.pagination a{text-decoration:none; color:#eaf1ff; border:1px solid var(--line); background:var(--glass); padding:.5rem .7rem; border-radius:10px}
+.pagination a.active{background:linear-gradient(90deg, var(--primary), var(--accent)); color:#0b1120; border-color:transparent}
+
+/* Skeletons */
+.skel{height:140px; border:1px solid var(--line); border-radius:18px;
+  background:linear-gradient(90deg, rgba(255,255,255,.05), rgba(255,255,255,.10), rgba(255,255,255,.05));
+  background-size:200% 100%; animation:wave 1.1s infinite}
+@keyframes wave{to{background-position: -200% 0}}
+
+/* Toast */
+.toast{position:fixed; left:50%; bottom:22px; transform:translateX(-50%) translateY(12px); opacity:0; background:var(--card); border:1px solid var(--line); padding:.6rem .85rem; border-radius:12px; box-shadow: var(--shadow); transition:.25s; z-index:99}
+.toast.show{opacity:1; transform:translateX(-50%) translateY(0)}
+
+/* Accesibilidad movimiento reducido */
+@media (prefers-reduced-motion: reduce){
+  body::before, body::after, .empty-state .dot{animation:none}
+}

--- a/templates/busqueda.html
+++ b/templates/busqueda.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <title>SkillMatch UBA — Buscar</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Fuente -->
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <!-- CSS -->
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/skillmatch_v2.css') }}">
+</head>
+<body>
+  <!-- Header -->
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="{{ url_for('buscar') }}"><span>SkillMatch</span> UBA</a>
+      <nav class="nav">
+        <a href="{{ url_for('buscar') }}">Buscar</a>
+        <a href="#">Subir</a>
+        <a href="#">Perfil</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="container">
+      <h1><span class="mark">Buscá</span> materiales</h1>
+      <p class="lead">Apuntes, parciales resueltos, enlaces y más. Filtrá por materias, tipo y formato.</p>
+
+      <form id="searchForm" class="searchbar" role="search">
+        <div class="input-wrap">
+          <input id="q" name="q" type="search" placeholder="Ej: parcial análisis | apunte álgebra | final algoritmos" aria-label="Buscar" autocomplete="off">
+        </div>
+        <button type="submit" class="btn btn-primary">Buscar</button>
+      </form>
+    </div>
+  </section>
+
+  <!-- App root: paso URL de API via data-* -->
+ <main id="app"
+      class="container layout"
+      data-api-url="{{ backend_url }}/api/publicaciones">
+    <!-- FILTROS -->
+    <aside class="filters" aria-label="Filtros">
+      <form id="filtersForm">
+        <fieldset>
+          <legend>Materias <small class="muted materias-counter" aria-live="polite"></small></legend>
+          <div class="input-with-icon">
+            <input id="materiaFilter" type="text" placeholder="Filtrar materias…" autocomplete="off">
+            <span class="icon">🔎</span>
+          </div>
+          <div id="materiasList" class="checklist" role="group" aria-label="Materias">
+            {% for m in materias %}
+            <label data-name="{{ m.nombre|lower }}">
+              <input class="ck" type="checkbox" name="materias" value="{{ m.id }}">
+              <span class="ckbox"></span>
+              <span class="cklabel">{{ m.nombre }}</span>
+            </label>
+            {% endfor %}
+          </div>
+          <div class="filter-actions">
+            <button type="button" class="btn btn-ghost" data-action="all">Seleccionar todo</button>
+            <button type="button" class="btn btn-ghost" data-action="none">Limpiar</button>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend>Tipo</legend>
+          <div id="tipoList" class="checklist tiny"></div>
+        </fieldset>
+
+        <fieldset>
+          <legend>Formato</legend>
+          <div id="formatoList" class="checklist tiny"></div>
+        </fieldset>
+
+        <div class="filter-footer">
+          <button type="submit" class="btn btn-primary">Aplicar filtros</button>
+          <button type="button" id="clearFilters" class="btn btn-ghost">Limpiar filtros</button>
+        </div>
+      </form>
+    </aside>
+
+    <!-- RESULTADOS -->
+    <section class="results">
+      <div class="results-bar">
+        <div id="resultsCount" aria-live="polite">Sin resultados aún</div>
+        <div class="bar-actions">
+          <label class="select">
+            <span>Ordenar</span>
+            <select id="sort" name="sort">
+              <option value="-fecha">Más nuevos</option>
+              <option value="-comentarios">Más comentados</option>
+              <option value="-rating">Mejor valorados</option>
+            </select>
+          </label>
+        </div>
+      </div>
+
+      <!-- Chips -->
+      <div id="chips" class="chips" aria-live="polite"></div>
+
+      <!-- Empty state (se muestra mientras no hay búsqueda o no llegaron datos) -->
+      <section id="empty" class="empty-state">
+        <div class="holo">
+          <div class="dot"></div><div class="dot"></div><div class="dot"></div>
+        </div>
+        <h2>Empezá una búsqueda</h2>
+        <p>Usá la barra y los filtros para ver publicaciones. Cuando haya resultados, van a aparecer acá.</p>
+      </section>
+
+      <!-- Grid -->
+      <ul id="grid" class="cards" hidden></ul>
+
+      <!-- Paginación -->
+      <nav id="pagination" class="pagination" aria-label="Paginación" hidden></nav>
+    </section>
+  </main>
+
+  <!-- Footer -->
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <div>© {{ 2025 }} SkillMatch UBA — Proyecto académico</div>
+      <div class="footer-links">
+        <a href="#">Términos</a>
+        <a href="#">Privacidad</a>
+        <a href="#">Contacto</a>
+      </div>
+    </div>
+  </footer>
+
+  <div id="toast" class="toast" role="status" aria-live="polite"></div>
+
+  <!-- JS -->
+  <script defer src="{{ url_for('static', filename='js/skillmatch_v2.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
- Agrega CSS unificado (paleta, tipografías y componentes: inputs, botones, cards, chips, checklist)
- Incorpora template `busqueda.html` (barra de búsqueda + checkboxes, responsive, sin datos hardcodeados)
- Suma ruta Flask para render y expone `data-api-url` para conectar con el backend separado

¿Por qué?
Para que el equipo clone y reutilice el mismo diseño/estilos en sus pantallas, evitando duplicar CSS y asegurando consistencia.

Cómo probar
- `python app.py` → http://127.0.0.1:5000/buscar

Archivos
- app.py
- templates/busqueda.html
- static/css/skillmatch_v2.css